### PR TITLE
Docs update + typescript

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,15 @@ const paginate = pagix({ records: 100 })
 
 The `pagix` function returns an object with some calculated props:
 
-- **total**: total pages to show in pagination
-- **current**: current page, between max and min total pages
-- **start**: an array with pages before prev button
-- **middle**: an array with pages between prev and next buttons
-- **end**: an array with pages after next button
-- **prev**: a page to set as current when click on prev button, or false
-- **next**: a page to set as current when click on next button, or false
-- **from**: initial record from current pagination
-- **to**: last record from current pagination
+- **total**: total number of pages
+- **current**: current page number, constrained between `1` and `total`
+- **start**: an array of page numbers, the first `fixed` page numbers
+- **middle**: an array of page numbers, calculated from `current` page
+- **end**: an array of page numbers, the last `fixed` page numbers
+- **prev**: the previous page number between `start` and `middle`, false if there is no truncated pages between `start` and `middle`
+- **next**: the next page number between `middle` and `end`, false if there is no truncated pages between `middle` and `end`
+- **from**: initial record in current page
+- **to**: last record in current page
 
 ![pagination explain](./pagination.png)
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,70 @@
+export function between(num: number, min: number, max: number): number;
+export function range(from: number, to: number): number[];
+
+export interface PagixOptions {
+	/**
+	 * total of records to paginate
+	 */
+	records: number;
+	/**
+	 * total of records to show per page
+	 * @default 10
+	 */
+	limit?: number;
+	/**
+	 * current page
+	 * @default 1
+	 */
+	current?: number;
+	/**
+	 * total of pages to show in each side of current page
+	 * @default 1
+	 */
+	delta?: number;
+	/**
+	 * total of pages to show before prev button and after next button
+	 * @default 1
+	 */
+	fixed?: number;
+}
+
+interface PagixReturn {
+	/**
+	 * total pages to show in pagination
+	 */
+	total: number;
+	/**
+	 * current page, between max and min total pages
+	 */
+	current: number;
+	/**
+	 * an array with pages before prev button
+	 */
+	start: number[];
+	/**
+	 * an array with pages between prev and next buttons
+	 */
+	middle: number[];
+	/**
+	 * an array with pages after next button
+	 */
+	end: number[];
+	/**
+	 * a page to set as current when click on next button, or false
+	 */
+	next: number | false;
+	/**
+	 * a page to set as current when click on prev button, or false
+	 */
+	prev: number | false;
+	/**
+	 * initial record from current pagination
+	 */
+	from: number;
+	/**
+	 * last record from current pagination
+	 */
+	to: number;
+}
+
+export function pagix(options: PagixOptions): PagixReturn;

--- a/index.d.ts
+++ b/index.d.ts
@@ -30,19 +30,19 @@ export interface PagixOptions {
 
 interface PagixReturn {
 	/**
-	 * total pages to show in pagination
+	 * total number of pages
 	 */
 	total: number;
 	/**
-	 * current page, between max and min total pages
+	 * current page number, constrained between `1` and `total`
 	 */
 	current: number;
 	/**
-	 * an array with pages before prev button
+	 * an array of page numbers, the first `fixed` page numbers
 	 */
 	start: number[];
 	/**
-	 * an array with pages between prev and next buttons
+	 * an array of page numbers, calculated from `current` page
 	 */
 	middle: number[];
 	/**
@@ -50,19 +50,21 @@ interface PagixReturn {
 	 */
 	end: number[];
 	/**
-	 * a page to set as current when click on next button, or false
+	 * the previous page number between `start` and `middle`
+	 * false if there is no truncated pages between `start` and `middle`
 	 */
 	next: number | false;
 	/**
-	 * a page to set as current when click on prev button, or false
+	 * the next page number between `middle` and `end`
+	 * false if there is no truncated pages between `middle` and `end`
 	 */
 	prev: number | false;
 	/**
-	 * initial record from current pagination
+	 * initial record in current pagination
 	 */
 	from: number;
 	/**
-	 * last record from current pagination
+	 * last record in current pagination
 	 */
 	to: number;
 }

--- a/package.json
+++ b/package.json
@@ -9,9 +9,11 @@
 	"source": "src/index.js",
 	"files": [
 		"dist/",
+		"index.d.ts",
 		"package.json",
 		"README.md"
 	],
+	"types": "index.d.ts",
 	"keywords": [
 		"pagination",
 		"pages",


### PR DESCRIPTION
This also includes the changes from #15 as I wanted to keep the typescript descriptions up to date as well.

I tried to re-word the descriptions of the return object to make it a little clear than `next` and `prev` are a little different to the usual usage of the words.